### PR TITLE
fix error on npm i

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gatsby-plugin-styled-components": "next",
     "gatsby-plugin-typography": "next",
     "gatsby-remark-autolink-headers": "next",
-    "gatsby-remark-external-links": "next",
+    "gatsby-remark-external-links": "0.0.4",
     "gatsby-remark-prismjs": "next",
     "gatsby-source-filesystem": "next",
     "gatsby-transformer-remark": "next",


### PR DESCRIPTION
There is no `next` version for `gatsby-remark-external-links` yet. This causes an error when running `npm i`. Here's the logs of what experience now:
```
npm ERR! code ETARGET
npm ERR! notarget No matching version found for gatsby-remark-external-links@next
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget
npm ERR! notarget It was specified as a dependency of 'gatsby-starter-minimal-blog'
npm ERR! notarget

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/joeprevite/.npm/_logs/2018-07-16T02_22_22_537Z-debug.log
error Command failed: npm install
```

By changing it to `0.0.4` (the latest version) it fixes that error when cloning. 