### PR TITLE
Fix order of media queries for p element

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -32,11 +32,11 @@ const Hero = styled.div`
   p {
     font-size: 1.68rem;
     margin-top: -1rem;
-    @media (max-width: ${props => props.theme.breakpoints.phone}) {
-      font-size: 1.25rem;
-    }
     @media (max-width: ${props => props.theme.breakpoints.tablet}) {
       font-size: 1.45rem;
+    }    
+    @media (max-width: ${props => props.theme.breakpoints.phone}) {
+      font-size: 1.25rem;
     }
   }
 `


### PR DESCRIPTION
The `tablet` media query should come before the `phone` one, so that you get the smaller font size on a phone