### PR TITLE
fix: Custom Slug overwrite

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,8 +20,7 @@ exports.onCreateNode = ({ node, actions }) => {
       Object.prototype.hasOwnProperty.call(node.frontmatter, 'slug')
     ) {
       slug = `/${_.kebabCase(node.frontmatter.slug)}`
-    }
-    if (
+    } else if (
       Object.prototype.hasOwnProperty.call(node, 'frontmatter') &&
       Object.prototype.hasOwnProperty.call(node.frontmatter, 'title')
     ) {


### PR DESCRIPTION
The current logic will overwrite any custom slugs assigned within an mdx file. Switching to an `else if` will help preserve them. To test

`blog/2019-01-20/index.mdx`

```
---
date: "2019-01-20"
title: "Using remark-images"
slug: "test-uri"
categories:
  - Remark
---

You can also use nearly all remark plugins, such as remark-images.

Here is an inline image

![](./315.jpg)

```

Note without the fix `/test-uri` will not resolve