### PR TITLE
add line numbers to code rendered with prism-react-renderer

### DIFF
--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -14,6 +14,13 @@ const StyledEditor = styled(LiveEditor)`
   margin-bottom: 1rem;
 `
 
+const LineNo = styled.span`
+  display: inline-block;
+  width: 2em;
+  user-select: none;
+  opacity: 0.3;
+`
+
 const Code = ({ codeString, language, ...props }) => {
   if (props['react-live']) {
     return (
@@ -30,6 +37,7 @@ const Code = ({ codeString, language, ...props }) => {
         <pre className={className} style={style}>
           {tokens.map((line, i) => (
             <div {...getLineProps({ line, key: i })}>
+              <LineNo>{i + 1}</LineNo>
               {line.map((token, key) => (
                 <span {...getTokenProps({ token, key })} />
               ))}


### PR DESCRIPTION
After searching online for awhile I was able to add line numbers to my forked gatsby-starter-minimal-blog. I thought they might also be useful in this theme.

I still need to figure out how to add them to react-live code. The screenshot below shows the theme with line numbers.

<img width="820" alt="Screen Shot 2019-10-27 at 17 54 20" src="https://user-images.githubusercontent.com/2707569/67642620-d701e100-f8e3-11e9-9d03-23c2a1247670.png">
